### PR TITLE
check LocationData for null on access of vibdelay

### DIFF
--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -1547,7 +1547,7 @@ void OPNMIDIplay::NoteUpdate(uint16_t MidCh,
                     phase = ains.fine_tune;//0.125; // Detune the note slightly (this is what Doom does)
                 }
 
-                if(Ch[MidCh].vibrato && d->vibdelay >= Ch[MidCh].vibdelay)
+                if(Ch[MidCh].vibrato && (!d || d->vibdelay >= Ch[MidCh].vibdelay))
                     bend += Ch[MidCh].vibrato * Ch[MidCh].vibdepth * std::sin(Ch[MidCh].vibpos);
 
 #define BEND_COEFFICIENT 321.88557


### PR DESCRIPTION
a suggestion to fix a null issue mentioned in #15 
