### PR TITLE
Fix a few things and unit test

### DIFF
--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -2635,3 +2635,121 @@ retry_arpeggio:
 //}
 
 //#endif//ADLMIDI_DISABLE_CPP_EXTRAS
+
+// Implement the user map data structure.
+
+bool OPNMIDIplay::OpnChannel::users_empty() const
+{
+    return !users_first;
+}
+
+OPNMIDIplay::OpnChannel::LocationData *OPNMIDIplay::OpnChannel::users_find(Location loc)
+{
+    LocationData *user = NULL;
+    for(LocationData *curr = users_first; !user && curr; curr = curr->next)
+        if(curr->loc == loc)
+            user = curr;
+    return user;
+}
+
+OPNMIDIplay::OpnChannel::LocationData *OPNMIDIplay::OpnChannel::users_allocate()
+{
+    // remove free cells front
+    LocationData *user = users_free_cells;
+    if(!user)
+        return NULL;
+    users_free_cells = user->next;
+    if(users_free_cells)
+        users_free_cells->prev = NULL;
+    // add to users front
+    if(users_first)
+        users_first->prev = user;
+    user->prev = NULL;
+    user->next = users_first;
+    users_first = user;
+    ++users_size;
+    return user;
+}
+
+OPNMIDIplay::OpnChannel::LocationData *OPNMIDIplay::OpnChannel::users_find_or_create(Location loc)
+{
+    LocationData *user = users_find(loc);
+    if(!user) {
+        user = users_allocate();
+        if(!user)
+            return NULL;
+        LocationData *prev = user->prev, *next = user->next;
+        *user = LocationData();
+        user->prev = prev; user->next = next;
+        user->loc = loc;
+    }
+    return user;
+}
+
+OPNMIDIplay::OpnChannel::LocationData *OPNMIDIplay::OpnChannel::users_insert(const LocationData &x)
+{
+    LocationData *user = users_find(x.loc);
+    if(!user)
+    {
+        user = users_allocate();
+        if(!user)
+            return NULL;
+        LocationData *prev = user->prev, *next = user->next;
+        *user = x;
+        user->prev = prev; user->next = next;
+    }
+    return user;
+}
+
+void OPNMIDIplay::OpnChannel::users_erase(LocationData *user)
+{
+    if(user->prev)
+        user->prev->next = user->next;
+    if(user->next)
+        user->next->prev = user->prev;
+    if(user == users_first)
+        users_first = user->next;
+    user->prev = NULL;
+    user->next = users_free_cells;
+    users_free_cells = user;
+    --users_size;
+}
+
+void OPNMIDIplay::OpnChannel::users_clear()
+{
+    users_first = NULL;
+    users_free_cells = users_cells;
+    users_size = 0;
+    for(size_t i = 0; i < users_max; ++i)
+    {
+        users_cells[i].prev = (i > 0) ? &users_cells[i - 1] : NULL;
+        users_cells[i].next = (i + 1 < users_max) ? &users_cells[i + 1] : NULL;
+    }
+}
+
+
+void OPNMIDIplay::OpnChannel::users_assign(const LocationData *users, size_t count)
+{
+    assert(count <= users_max);
+    if(users == users_first) {
+        // self assignment
+        assert(users_size == count);
+        return;
+    }
+    users_clear();
+    const LocationData *src_cell = users;
+    // move to the last
+    if(src_cell) {
+        while(src_cell->next)
+            src_cell = src_cell->next;
+    }
+    // push cell copies in reverse order
+    while(src_cell) {
+        LocationData *dst_cell = users_allocate();
+        assert(dst_cell);
+        LocationData *prev = dst_cell->prev, *next = dst_cell->next;
+        *dst_cell = *src_cell;
+        dst_cell->prev = prev; dst_cell->next = next;
+    }
+    assert(users_size == count);
+}

--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -2359,17 +2359,7 @@ uint64_t OPNMIDIplay::ChooseDevice(const std::string &name)
 
     size_t n = devices.size() * 16;
     devices.insert(std::make_pair(name, n));
-
-    size_t channelsBefore = Ch.size();
-    size_t channels = n + 16;
-    Ch.resize(channels);
-
-    for(size_t ch = channelsBefore; ch < channels; ++ch) {
-        for(unsigned i = 0; i < 128; ++i) {
-            Ch[ch].activenotes[i].note = i;
-            Ch[ch].activenotes[i].active = false;
-        }
-    }
+    Ch.resize(n + 16);
     return n;
 }
 
@@ -2727,7 +2717,6 @@ void OPNMIDIplay::OpnChannel::users_clear()
     }
 }
 
-
 void OPNMIDIplay::OpnChannel::users_assign(const LocationData *users, size_t count)
 {
     assert(count <= users_max);
@@ -2750,6 +2739,7 @@ void OPNMIDIplay::OpnChannel::users_assign(const LocationData *users, size_t cou
         LocationData *prev = dst_cell->prev, *next = dst_cell->next;
         *dst_cell = *src_cell;
         dst_cell->prev = prev; dst_cell->next = next;
+        src_cell = src_cell->prev;
     }
     assert(users_size == count);
 }

--- a/src/opnmidi_private.hpp
+++ b/src/opnmidi_private.hpp
@@ -673,6 +673,7 @@ public:
 
         activenoteiterator activenotes_find(uint8_t note)
         {
+            assert(note < 128);
             return activenoteiterator(
                 activenotes[note].active ? &activenotes[note] : NULL);
         }
@@ -686,6 +687,7 @@ public:
 
         std::pair<activenoteiterator, bool> activenotes_insert(uint8_t note)
         {
+            assert(note < 128);
             NoteInfo &info = activenotes[note];
             bool inserted = !info.active;
             if(inserted) info.active = true;
@@ -701,6 +703,14 @@ public:
         bool activenotes_empty()
         {
             return !activenotes_begin();
+        }
+
+        void activenotes_clear()
+        {
+            for(unsigned i = 0; i < 128; ++i) {
+                activenotes[i].note = i;
+                activenotes[i].active = false;
+            }
         }
 
         void reset()
@@ -732,8 +742,8 @@ public:
         }
 
         MIDIchannel()
-            : activenotes()
         {
+            activenotes_clear();
             reset();
         }
     };

--- a/src/opnmidi_private.hpp
+++ b/src/opnmidi_private.hpp
@@ -770,86 +770,33 @@ public:
         LocationData users_cells[users_max];
         unsigned users_size;
 
-        bool users_empty() const
-            { return !users_first; }
-        LocationData *users_find(Location loc)
-        {
-            LocationData *user = NULL;
-            for(LocationData *curr = users_first; !user && curr; curr = curr->next)
-                if(curr->loc == loc)
-                    user = curr;
-            return user;
-        }
-        LocationData *users_allocate()
-        {
-            // remove free cells front
-            LocationData *user = users_free_cells;
-            if(!user)
-                return NULL;
-            users_free_cells = user->next;
-            if(users_free_cells)
-                users_free_cells->prev = NULL;
-            // add to users front
-            if(users_first)
-                users_first->prev = user;
-            user->prev = NULL;
-            user->next = users_first;
-            users_first = user;
-            ++users_size;
-            return user;
-        }
-        LocationData *users_find_or_create(Location loc)
-        {
-            LocationData *user = users_find(loc);
-            if(!user) {
-                user = users_allocate();
-                if(!user)
-                    return NULL;
-                LocationData *prev = user->prev, *next = user->next;
-                *user = LocationData();
-                user->prev = prev; user->next = next;
-                user->loc = loc;
-            }
-            return user;
-        }
-        LocationData *users_insert(const LocationData &x)
-        {
-            LocationData *user = users_find(x.loc);
-            if(!user)
-            {
-                user = users_allocate();
-                if(!user)
-                    return NULL;
-                LocationData *prev = user->prev, *next = user->next;
-                *user = x;
-                user->prev = prev; user->next = next;
-            }
-            return user;
-        }
-        void users_erase(LocationData *user)
-        {
-            if(user->prev)
-                user->prev->next = user->next;
-            if(user->next)
-                user->next->prev = user->prev;
-            if(user == users_first)
-                users_first = user->next;
-            user->prev = NULL;
-            user->next = users_free_cells;
-            users_free_cells = user;
-            --users_size;
-        }
+        bool users_empty() const;
+        LocationData *users_find(Location loc);
+        LocationData *users_allocate();
+        LocationData *users_find_or_create(Location loc);
+        LocationData *users_insert(const LocationData &x);
+        void users_erase(LocationData *user);
+        void users_clear();
+        void users_assign(const LocationData *users, size_t count);
 
         // For channel allocation:
-        OpnChannel(): koff_time_until_neglible(0), users_first(NULL), users_size(0)
+        OpnChannel(): koff_time_until_neglible(0)
         {
-            users_free_cells = users_cells;
-            for(size_t i = 0; i < users_max; ++i)
-            {
-                users_cells[i].prev = (i > 0) ? &users_cells[i - 1] : NULL;
-                users_cells[i].next = (i + 1 < users_max) ? &users_cells[i + 1] : NULL;
-            }
+            users_clear();
         }
+
+        OpnChannel(const OpnChannel &oth): koff_time_until_neglible(oth.koff_time_until_neglible)
+        {
+            users_assign(oth.users_first, oth.users_size);
+        }
+
+        OpnChannel &operator=(const OpnChannel &oth)
+         {
+             koff_time_until_neglible = oth.koff_time_until_neglible;
+             users_assign(oth.users_first, oth.users_size);
+             return *this;
+         }
+
         void AddAge(int64_t ms);
     };
 


### PR DESCRIPTION
1.

I reject the activenotes unit test as **invalid**. :smile:

In that test the members {note, active} of `NoteInfo` are not initialized. Before, I made these initialized at the level of `ChooseDevice`. To arrange things better and make the unit test pass, I set them up in the constructor of the channel.
Please note about `Ch.resize(n +16)`: it's not necessary to pass a second argument. It's probably better not to, for the sake of C++ version 11 and up.

2.

I modified the user map. First, for the sake of code organization, implementations go in .cpp. I did not modify any of the existing implementation.
However I added the **copy** methods. These are required because copying a `LocationData` into another will have an ill effect of copying the list's head pointers into the other. The pointers from different cell storages will mix, with the effects you can probably guess.
The copy method will reproduce the list of the other into its own storage. I add the asserts here and there to fortify code checks against potential errors.