### PR TITLE
check for null on self-assignment + test

### DIFF
--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -2720,7 +2720,7 @@ void OPNMIDIplay::OpnChannel::users_clear()
 void OPNMIDIplay::OpnChannel::users_assign(const LocationData *users, size_t count)
 {
     assert(count <= users_max);
-    if(users == users_first) {
+    if(users == users_first && users) {
         // self assignment
         assert(users_size == count);
         return;

--- a/test/channel-users/channel_users.cpp
+++ b/test/channel-users/channel_users.cpp
@@ -217,3 +217,18 @@ TEST_CASE("[OPNMIDIplay::OpnChannel] User list: appending full")
     REQUIRE(channel.users_size == Channel::users_max);
     REQUIRE(consistent_size(channel));
 }
+
+TEST_CASE("[OPNMIDIplay::OpnChannel] User list: assigning empty lists")
+{
+    Channel channel1;
+    REQUIRE(channel1.users_size == 0);
+    REQUIRE(consistent_size(channel1));
+
+    Channel channel2;
+    REQUIRE(channel2.users_size == 0);
+    REQUIRE(consistent_size(channel2));
+
+    channel1 = channel2;
+    REQUIRE(channel1.users_size == 0);
+    REQUIRE(consistent_size(channel1));
+}


### PR DESCRIPTION
Fixes bug mentioned in #18 

Adds the unit test. But it will only detect in Debug mode (without -DNDEBUG).