### PR TITLE
Chip base

### DIFF
--- a/src/chips/gens_opn2.cpp
+++ b/src/chips/gens_opn2.cpp
@@ -3,16 +3,9 @@
 
 #include "gens/Ym2612_Emu.h"
 
-GensOPN2::GensOPN2() : OPNChipBase(),
-    chip(new Ym2612_Emu())
+GensOPN2::GensOPN2()
+    : chip(new Ym2612_Emu())
 {}
-
-GensOPN2::GensOPN2(const GensOPN2 &c) :
-    OPNChipBase(c),
-    chip(new Ym2612_Emu())
-{
-    reset(m_rate, m_clock);
-}
 
 GensOPN2::~GensOPN2()
 {

--- a/src/chips/gens_opn2.h
+++ b/src/chips/gens_opn2.h
@@ -10,15 +10,15 @@ class GensOPN2 final : public OPNChipBase
 public:
     GensOPN2();
     GensOPN2(const GensOPN2 &c);
-    virtual ~GensOPN2() override;
+    ~GensOPN2() override;
 
-    virtual void setRate(uint32_t rate, uint32_t clock) override;
-    virtual void reset() override;
-    virtual void reset(uint32_t rate, uint32_t clock) override;
-    virtual void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;
-    virtual int generate(int16_t *output, size_t frames) override;
-    virtual int generateAndMix(int16_t *output, size_t frames) override;
-    virtual const char *emulatorName() override;
+    void setRate(uint32_t rate, uint32_t clock) override;
+    void reset() override;
+    void reset(uint32_t rate, uint32_t clock) override;
+    void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;
+    int generate(int16_t *output, size_t frames) override;
+    int generateAndMix(int16_t *output, size_t frames) override;
+    const char *emulatorName() override;
 };
 
 #endif // GENS_OPN2_H

--- a/src/chips/gens_opn2.h
+++ b/src/chips/gens_opn2.h
@@ -4,12 +4,11 @@
 #include "opn_chip_base.h"
 
 class Ym2612_Emu;
-class GensOPN2 final : public OPNChipBase
+class GensOPN2 final : public OPNChipBaseT<GensOPN2>
 {
     Ym2612_Emu *chip;
 public:
     GensOPN2();
-    GensOPN2(const GensOPN2 &c);
     ~GensOPN2() override;
 
     void setRate(uint32_t rate, uint32_t clock) override;

--- a/src/chips/mame_opn2.cpp
+++ b/src/chips/mame_opn2.cpp
@@ -8,8 +8,7 @@
 #include <zita-resampler/vresampler.h>
 #endif
 
-MameOPN2::MameOPN2() :
-    OPNChipBase()
+MameOPN2::MameOPN2()
 {
     chip = NULL;
 #if defined(OPNMIDI_ENABLE_HQ_RESAMPLER)

--- a/src/chips/mame_opn2.h
+++ b/src/chips/mame_opn2.h
@@ -15,15 +15,15 @@ class MameOPN2 final : public OPNChipBase
 #endif
 public:
     MameOPN2();
-    virtual ~MameOPN2() override;
+    ~MameOPN2() override;
 
-    virtual void setRate(uint32_t rate, uint32_t clock) override;
-    virtual void reset() override;
-    virtual void reset(uint32_t rate, uint32_t clock) override;
-    virtual void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;
-    virtual int generate(int16_t *output, size_t frames) override;
-    virtual int generateAndMix(int16_t *output, size_t frames) override;
-    virtual const char *emulatorName() override;
+    void setRate(uint32_t rate, uint32_t clock) override;
+    void reset() override;
+    void reset(uint32_t rate, uint32_t clock) override;
+    void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;
+    int generate(int16_t *output, size_t frames) override;
+    int generateAndMix(int16_t *output, size_t frames) override;
+    const char *emulatorName() override;
 private:
 #if defined(OPNMIDI_ENABLE_HQ_RESAMPLER)
     void generateResampledHq(int16_t *out);

--- a/src/chips/mame_opn2.h
+++ b/src/chips/mame_opn2.h
@@ -7,7 +7,7 @@
 class VResampler;
 #endif
 
-class MameOPN2 final : public OPNChipBase
+class MameOPN2 final : public OPNChipBaseT<MameOPN2>
 {
     void *chip;
 #if defined(OPNMIDI_ENABLE_HQ_RESAMPLER)

--- a/src/chips/nuked_opn2.cpp
+++ b/src/chips/nuked_opn2.cpp
@@ -2,19 +2,10 @@
 #include "nuked/ym3438.h"
 #include <cstring>
 
-NukedOPN2::NukedOPN2() :
-    OPNChipBase()
+NukedOPN2::NukedOPN2()
 {
     OPN2_SetChipType(ym3438_type_asic);
     chip = new ym3438_t;
-}
-
-NukedOPN2::NukedOPN2(const NukedOPN2 &c):
-    OPNChipBase(c)
-{
-    chip = new ym3438_t;
-    std::memset(chip, 0, sizeof(ym3438_t));
-    reset(c.m_rate, c.m_clock);
 }
 
 NukedOPN2::~NukedOPN2()

--- a/src/chips/nuked_opn2.h
+++ b/src/chips/nuked_opn2.h
@@ -9,17 +9,17 @@ class NukedOPN2 final : public OPNChipBase
 public:
     NukedOPN2();
     NukedOPN2(const NukedOPN2 &c);
-    virtual ~NukedOPN2() override;
+    ~NukedOPN2() override;
 
-    virtual void setRate(uint32_t rate, uint32_t clock) override;
-    virtual void reset() override;
-    virtual void reset(uint32_t rate, uint32_t clock) override;
-    virtual void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;
-    virtual int generate(int16_t *output, size_t frames) override;
-    virtual int generateAndMix(int16_t *output, size_t frames) override;
-    virtual int generate32(int32_t *output, size_t frames) override;
-    virtual int generateAndMix32(int32_t *output, size_t frames) override;
-    virtual const char *emulatorName() override;
+    void setRate(uint32_t rate, uint32_t clock) override;
+    void reset() override;
+    void reset(uint32_t rate, uint32_t clock) override;
+    void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;
+    int generate(int16_t *output, size_t frames) override;
+    int generateAndMix(int16_t *output, size_t frames) override;
+    int generate32(int32_t *output, size_t frames) override;
+    int generateAndMix32(int32_t *output, size_t frames) override;
+    const char *emulatorName() override;
 };
 
 #endif // NUKED_OPN2_H

--- a/src/chips/nuked_opn2.h
+++ b/src/chips/nuked_opn2.h
@@ -3,12 +3,11 @@
 
 #include "opn_chip_base.h"
 
-class NukedOPN2 final : public OPNChipBase
+class NukedOPN2 final : public OPNChipBaseT<NukedOPN2>
 {
     void *chip;
 public:
     NukedOPN2();
-    NukedOPN2(const NukedOPN2 &c);
     ~NukedOPN2() override;
 
     void setRate(uint32_t rate, uint32_t clock) override;

--- a/src/chips/opn_chip_base.cpp
+++ b/src/chips/opn_chip_base.cpp
@@ -5,11 +5,6 @@ OPNChipBase::OPNChipBase() :
     m_clock(7670454)
 {}
 
-OPNChipBase::OPNChipBase(const OPNChipBase &c):
-    m_rate(c.m_rate),
-    m_clock(c.m_clock)
-{}
-
 OPNChipBase::~OPNChipBase()
 {}
 
@@ -22,34 +17,4 @@ void OPNChipBase::setRate(uint32_t rate, uint32_t clock)
 void OPNChipBase::reset(uint32_t rate, uint32_t clock)
 {
     setRate(rate, clock);
-}
-
-int OPNChipBase::generate32(int32_t *output, size_t frames)
-{
-    enum { maxFramesAtOnce = 256 };
-    int16_t temp[2 * maxFramesAtOnce];
-    for(size_t left = frames; left > 0;) {
-        size_t count = (left < (size_t)maxFramesAtOnce) ? left : (size_t)maxFramesAtOnce;
-        int16_t *temp_it = temp;
-        generate(temp, count);
-        for(size_t i = 0; i < 2 * count; ++i)
-            *(output++) = *(temp_it++);
-        left -= count;
-    }
-    return (int)frames;
-}
-
-int OPNChipBase::generateAndMix32(int32_t *output, size_t frames)
-{
-    enum { maxFramesAtOnce = 256 };
-    int16_t temp[2 * maxFramesAtOnce];
-    for(size_t left = frames; left > 0;) {
-        size_t count = (left < (size_t)maxFramesAtOnce) ? left : (size_t)maxFramesAtOnce;
-        int16_t *temp_it = temp;
-        generate(temp, count);
-        for(size_t i = 0; i < 2 * count; ++i)
-            *(output++) += *(temp_it++);
-        left -= count;
-    }
-    return (int)frames;
 }

--- a/src/chips/opn_chip_base.h
+++ b/src/chips/opn_chip_base.h
@@ -16,7 +16,6 @@ protected:
     uint32_t m_clock;
 public:
     OPNChipBase();
-    OPNChipBase(const OPNChipBase &c);
     virtual ~OPNChipBase();
 
     virtual void setRate(uint32_t rate, uint32_t clock);
@@ -25,9 +24,26 @@ public:
     virtual void writeReg(uint32_t port, uint16_t addr, uint8_t data) = 0;
     virtual int generate(int16_t *output, size_t frames) = 0;
     virtual int generateAndMix(int16_t *output, size_t frames) = 0;
-    virtual int generate32(int32_t *output, size_t frames);
-    virtual int generateAndMix32(int32_t *output, size_t frames);
+    virtual int generate32(int32_t *output, size_t frames) = 0;
+    virtual int generateAndMix32(int32_t *output, size_t frames) = 0;
     virtual const char* emulatorName() = 0;
+private:
+    OPNChipBase(const OPNChipBase &c);
+    OPNChipBase &operator=(const OPNChipBase &c);
 };
+
+template <class T>
+class OPNChipBaseT : public OPNChipBase
+{
+public:
+    OPNChipBaseT()
+        : OPNChipBase() {}
+    virtual ~OPNChipBaseT()
+        {}
+    virtual int generate32(int32_t *output, size_t frames) override;
+    virtual int generateAndMix32(int32_t *output, size_t frames) override;
+};
+
+#include "opn_chip_base.tcc"
 
 #endif // ONP_CHIP_BASE_H

--- a/src/chips/opn_chip_base.tcc
+++ b/src/chips/opn_chip_base.tcc
@@ -1,0 +1,33 @@
+#include "opn_chip_base.h"
+
+template <class T>
+int OPNChipBaseT<T>::generate32(int32_t *output, size_t frames)
+{
+    enum { maxFramesAtOnce = 256 };
+    int16_t temp[2 * maxFramesAtOnce];
+    for(size_t left = frames; left > 0;) {
+        size_t count = (left < (size_t)maxFramesAtOnce) ? left : (size_t)maxFramesAtOnce;
+        int16_t *temp_it = temp;
+        static_cast<T *>(this)->generate(temp, count);
+        for(size_t i = 0; i < 2 * count; ++i)
+            *(output++) = *(temp_it++);
+        left -= count;
+    }
+    return (int)frames;
+}
+
+template <class T>
+int OPNChipBaseT<T>::generateAndMix32(int32_t *output, size_t frames)
+{
+    enum { maxFramesAtOnce = 256 };
+    int16_t temp[2 * maxFramesAtOnce];
+    for(size_t left = frames; left > 0;) {
+        size_t count = (left < (size_t)maxFramesAtOnce) ? left : (size_t)maxFramesAtOnce;
+        int16_t *temp_it = temp;
+        static_cast<T *>(this)->generate(temp, count);
+        for(size_t i = 0; i < 2 * count; ++i)
+            *(output++) += *(temp_it++);
+        left -= count;
+    }
+    return (int)frames;
+}


### PR DESCRIPTION
This is a tiny reorganization in order to improve efficiency.

I redo `OPNChipBase` in F-bounded generics (aka CRTP in common C++ lingo). Here is an explanation of the goal of doing this:

Currently, it permits to eliminate the virtual calls in the `generate32` fallback.
These kinds of virtual calls are to avoid because they are invoked on a frame by frame basis.

But later, this will allow me, with the same efficiency benefit, to generalize to all chips the resampling method. All a chip will have to do is to provide a generator function for the next frame at native rate.
So, all chip implementations will be able to be simplified and be kept fast, while moving the common code into the Chip Base.

And then, there will be a true and efficient way to drive chips for frame-by-frame work, and it will facilitate the implementation of portamento (which has to interleave `Upd_Pitch` between generation of frames at near audio rate).

Remark: I'm also getting rid of copy constructors, as it's not only useless but also copy gets complicated when resampler variables are getting involved