### PR TITLE
chips: discard the buffer on reset()

### DIFF
--- a/src/chips/opn_chip_base.h
+++ b/src/chips/opn_chip_base.h
@@ -86,6 +86,7 @@ public:
     virtual ~OPNChipBaseBufferedT()
         {}
 public:
+    void reset() override;
     void nativeGenerate(int16_t *frame) override;
 protected:
     virtual void nativeGenerateN(int16_t *output, size_t frames) = 0;

--- a/src/chips/opn_chip_base.tcc
+++ b/src/chips/opn_chip_base.tcc
@@ -197,6 +197,13 @@ void OPNChipBaseT<T>::resampledGenerate(int32_t *output)
 /* OPNChipBaseBufferedT */
 
 template <class T, unsigned Buffer>
+void OPNChipBaseBufferedT<T, Buffer>::reset()
+{
+    OPNChipBaseT<T>::reset();
+    m_bufferIndex = 0;
+}
+
+template <class T, unsigned Buffer>
 void OPNChipBaseBufferedT<T, Buffer>::nativeGenerate(int16_t *frame)
 {
     unsigned bufferIndex = m_bufferIndex;


### PR DESCRIPTION
Discard the potential contents of buffer when the chip is reset.