### PR TITLE
gx: initialize in the constructor

### DIFF
--- a/src/chips/gx_opn2.cpp
+++ b/src/chips/gx_opn2.cpp
@@ -9,6 +9,7 @@ GXOPN2::GXOPN2()
 {
     YM2612GXInit(m_chip);
     YM2612GXConfig(m_chip, YM2612_DISCRETE);
+    setRate(m_rate, m_clock);
 }
 
 GXOPN2::~GXOPN2()


### PR DESCRIPTION
It's the same as done in the 2 other chip types.
Unless GX gets it initial reset it enters an infinite loop at generation.
