### PR TITLE
don't forget to increment sample pointer in generate16

### DIFF
--- a/src/chips/opn_chip_base.tcc
+++ b/src/chips/opn_chip_base.tcc
@@ -67,8 +67,9 @@ void OPNChipBaseT<T>::generate(int16_t *output, size_t frames)
             int32_t temp = frame[c];
             temp = (temp > -32768) ? temp : -32768;
             temp = (temp < 32767) ? temp : 32767;
-            output[c] = temp;
+            output[c] = (int16_t)temp;
         }
+        output += 2;
     }
     static_cast<T *>(this)->nativePostGenerate();
 }
@@ -85,8 +86,9 @@ void OPNChipBaseT<T>::generateAndMix(int16_t *output, size_t frames)
             int32_t temp = (int32_t)output[c] + frame[c];
             temp = (temp > -32768) ? temp : -32768;
             temp = (temp < 32767) ? temp : 32767;
-            output[c] = temp;
+            output[c] = (int16_t)temp;
         }
+        output += 2;
     }
     static_cast<T *>(this)->nativePostGenerate();
 }


### PR DESCRIPTION
Fix the 16-bit generation case where the frame pointer is not incremented.
(and shut up a warning)