### PR TITLE
extend chip API for generation at PCM rate

### DIFF
--- a/src/chips/gens_opn2.cpp
+++ b/src/chips/gens_opn2.cpp
@@ -17,7 +17,8 @@ GensOPN2::~GensOPN2()
 void GensOPN2::setRate(uint32_t rate, uint32_t clock)
 {
     OPNChipBaseBufferedT::setRate(rate, clock);
-    chip->set_rate(53267, clock);  // implies reset()
+    uint32_t chipRate = isRunningAtPcmRate() ? rate : nativeRate;
+    chip->set_rate(chipRate, clock);  // implies reset()
 }
 
 void GensOPN2::reset()

--- a/src/chips/gens_opn2.h
+++ b/src/chips/gens_opn2.h
@@ -11,6 +11,7 @@ public:
     GensOPN2();
     ~GensOPN2() override;
 
+    bool canRunAtPcmRate() const override { return true; }
     void setRate(uint32_t rate, uint32_t clock) override;
     void reset() override;
     void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;

--- a/src/chips/gx_opn2.h
+++ b/src/chips/gx_opn2.h
@@ -12,6 +12,7 @@ public:
     GXOPN2();
     ~GXOPN2() override;
 
+    bool canRunAtPcmRate() const override { return false; }
     void setRate(uint32_t rate, uint32_t clock) override;
     void reset() override;
     void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;

--- a/src/chips/mame_opn2.cpp
+++ b/src/chips/mame_opn2.cpp
@@ -19,7 +19,8 @@ void MameOPN2::setRate(uint32_t rate, uint32_t clock)
     OPNChipBaseT::setRate(rate, clock);
     if(chip)
         ym2612_shutdown(chip);
-    chip = ym2612_init(NULL, (int)clock, (int)rate, NULL, NULL);
+    uint32_t chipRate = isRunningAtPcmRate() ? rate : nativeRate;
+    chip = ym2612_init(NULL, (int)clock, (int)chipRate, NULL, NULL);
     ym2612_reset_chip(chip);
 }
 

--- a/src/chips/mame_opn2.h
+++ b/src/chips/mame_opn2.h
@@ -10,6 +10,7 @@ public:
     MameOPN2();
     ~MameOPN2() override;
 
+    bool canRunAtPcmRate() const override { return true; }
     void setRate(uint32_t rate, uint32_t clock) override;
     void reset() override;
     void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;

--- a/src/chips/nuked_opn2.h
+++ b/src/chips/nuked_opn2.h
@@ -10,6 +10,7 @@ public:
     NukedOPN2();
     ~NukedOPN2() override;
 
+    bool canRunAtPcmRate() const override { return false; }
     void setRate(uint32_t rate, uint32_t clock) override;
     void reset() override;
     void writeReg(uint32_t port, uint16_t addr, uint8_t data) override;

--- a/src/chips/opn_chip_base.h
+++ b/src/chips/opn_chip_base.h
@@ -15,12 +15,18 @@ class VResampler;
 
 class OPNChipBase
 {
+public:
+    enum { nativeRate = 53267 };
 protected:
     uint32_t m_rate;
     uint32_t m_clock;
 public:
     OPNChipBase();
     virtual ~OPNChipBase();
+
+    virtual bool canRunAtPcmRate() const = 0;
+    virtual bool isRunningAtPcmRate() const = 0;
+    virtual bool setRunningAtPcmRate(bool r) = 0;
 
     virtual void setRate(uint32_t rate, uint32_t clock) = 0;
     virtual void reset() = 0;
@@ -50,6 +56,9 @@ public:
     OPNChipBaseT();
     virtual ~OPNChipBaseT();
 
+    bool isRunningAtPcmRate() const override;
+    bool setRunningAtPcmRate(bool r) override;
+
     virtual void setRate(uint32_t rate, uint32_t clock) override;
     virtual void reset() override;
     void generate(int16_t *output, size_t frames) override;
@@ -57,6 +66,7 @@ public:
     void generate32(int32_t *output, size_t frames) override;
     void generateAndMix32(int32_t *output, size_t frames) override;
 private:
+    bool m_runningAtPcmRate;
     void setupResampler(uint32_t rate);
     void resetResampler();
     void resampledGenerate(int32_t *output);


### PR DESCRIPTION
This is more generic chip API which will permit any chip, not just MAME, to generate directly at PCM rate if the emulator supports it.

I provide this support in Gens and MAME. For MAME, I had to make changes in order to bypass the resampler logic.

There is not yet an external API to manage this. Internally, the program must invoke `chip->setRunningAtPcmRate(true)` and the boolean result indicates if the emulator supports this or not.

For APIs to configure emulation options, I had in mind a generic configuration like curl setopt.
(another setting of potential interest is the access to the chip modes of some emulators)