### PR TITLE
mark Genesis Plus GX as experimental feature, and make default OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ option(WITH_XMI_SUPPORT     "Build with support for AIL XMI files)" ON)
 option(USE_MAME_EMULATOR    "Use MAME YM2612 emulator (for most of hardware)" ON)
 option(USE_GENS_EMULATOR    "Use GENS 2.10 emulator (fastest, very outdated, inaccurate)" ON)
 option(USE_NUKED_EMULATOR   "Use Nuked OPN2 emulator (most accurate, heavy)" ON)
-option(USE_GX_EMULATOR      "Use Genesis Plus GX emulator" ON)
+option(USE_GX_EMULATOR      "Use Genesis Plus GX emulator (experimental)" OFF)
 # WIP FEATURES
 # option(WITH_CPP_EXTRAS      "Build with support for C++ extras (features are can be found in 'adlmidi.hpp' header)" OFF)
 


### PR DESCRIPTION
It's maybe preferable to keep this disabled as it has some problems.
On adljack side, I will prefer the emulator choice not shown in default builds for the moment.