### PR TITLE
hide private symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,15 @@ function(set_legacy_standard destTarget)
         endif()
     endif()
 endfunction()
+
+function(set_visibility_hidden destTarget)
+    if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang)$")
+        target_compile_options(${destTarget} PRIVATE
+          -fvisibility=hidden -fvisibility-inlines-hidden)
+        target_compile_definitions(${destTarget} PRIVATE
+          "LIBADLMIDI_VISIBILITY")
+    endif()
+endfunction()
 #===========================================================================================
 
 option(libOPNMIDI_STATIC   "Build static library of libOPNMIDI" ON)
@@ -174,6 +183,7 @@ if(libOPNMIDI_STATIC)
     set_target_properties(OPNMIDI_static PROPERTIES OUTPUT_NAME OPNMIDI)
     target_include_directories(OPNMIDI_static PUBLIC ${libOPNMIDI_SOURCE_DIR}/include)
     set_legacy_standard(OPNMIDI_static)
+    set_visibility_hidden(OPNMIDI_static)
     list(APPEND libOPNMIDI_INSTALLS OPNMIDI_static)
 endif()
 
@@ -182,6 +192,7 @@ if(libOPNMIDI_SHARED)
     set_target_properties(OPNMIDI_shared PROPERTIES OUTPUT_NAME OPNMIDI)
     target_include_directories(OPNMIDI_shared PUBLIC ${libOPNMIDI_SOURCE_DIR}/include)
     set_legacy_standard(OPNMIDI_shared)
+    set_visibility_hidden(OPNMIDI_shared)
     list(APPEND libOPNMIDI_INSTALLS OPNMIDI_shared)
 endif()
 

--- a/src/opnmidi.cpp
+++ b/src/opnmidi.cpp
@@ -67,7 +67,7 @@ OPNMIDI_EXPORT struct OPN2_MIDIPlayer *opn2_init(long sample_rate)
     return midi_device;
 }
 
-OPNMIDI_EXPORT int adl_setDeviceIdentifier(OPN2_MIDIPlayer *device, unsigned id)
+OPNMIDI_EXPORT int opn2_setDeviceIdentifier(OPN2_MIDIPlayer *device, unsigned id)
 {
     if(!device || id > 0x0f)
         return -1;

--- a/src/opnmidi_private.hpp
+++ b/src/opnmidi_private.hpp
@@ -28,7 +28,7 @@
 #ifndef OPNMIDI_EXPORT
 #   if defined (_WIN32) && defined(ADLMIDI_BUILD_DLL)
 #       define OPNMIDI_EXPORT __declspec(dllexport)
-#   elif defined (LIBADLMIDI_VISIBILITY)
+#   elif defined (LIBADLMIDI_VISIBILITY) && defined (__GNUC__)
 #       define OPNMIDI_EXPORT __attribute__((visibility ("default")))
 #   else
 #       define OPNMIDI_EXPORT

--- a/test/activenotes/CMakeLists.txt
+++ b/test/activenotes/CMakeLists.txt
@@ -7,9 +7,16 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/../common
 
 add_executable (ActiveNotesList
                 active_notes.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/opnmidi_midiplay.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/opnmidi_opn2.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/chips/nuked_opn2.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/chips/nuked/ym3438.c
                 $<TARGET_OBJECTS:Catch-objects>)
 
 set_target_properties(ActiveNotesList PROPERTIES COMPILE_DEFINITIONS "GSL_THROW_ON_CONTRACT_VIOLATION")
-target_link_libraries(ActiveNotesList PRIVATE OPNMIDI_IF)
-target_compile_definitions(ActiveNotesList PRIVATE OPNMIDI_AUDIO_TICK_HANDLER)
+target_compile_definitions(ActiveNotesList PRIVATE
+  OPNMIDI_DISABLE_MIDI_SEQUENCER
+  OPNMIDI_DISABLE_GENS_EMULATOR
+  OPNMIDI_DISABLE_MAME_EMULATOR
+  OPNMIDI_DISABLE_GX_EMULATOR)
 add_test(NAME ActiveNotesList COMMAND ActiveNotesList)

--- a/test/channel-users/CMakeLists.txt
+++ b/test/channel-users/CMakeLists.txt
@@ -7,10 +7,17 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/../common
 
 add_executable(ChannelUsersTest
                channel_users.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/opnmidi_midiplay.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/opnmidi_opn2.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/chips/nuked_opn2.cpp
+                ${libOPNMIDI_SOURCE_DIR}/src/chips/nuked/ym3438.c
                $<TARGET_OBJECTS:Catch-objects>)
 
 set_target_properties(ChannelUsersTest PROPERTIES COMPILE_DEFINITIONS "GSL_THROW_ON_CONTRACT_VIOLATION")
-target_link_libraries(ChannelUsersTest PRIVATE OPNMIDI_IF)
-target_compile_definitions(ChannelUsersTest PRIVATE OPNMIDI_AUDIO_TICK_HANDLER)
+target_compile_definitions(ChannelUsersTest PRIVATE
+  OPNMIDI_DISABLE_MIDI_SEQUENCER
+  OPNMIDI_DISABLE_GENS_EMULATOR
+  OPNMIDI_DISABLE_MAME_EMULATOR
+  OPNMIDI_DISABLE_GX_EMULATOR)
 add_test(NAME ChannelUsersTest COMMAND ChannelUsersTest)
 


### PR DESCRIPTION
The same as libADLMIDI for a cleanup of the exposed symbols.

Also fixed: a misnamed function found after looking at objdump outputs

Note about unit tests: they cannot link libOPNMIDI to access internals of libraries, considering they now have the symbols hidden.
I make the unit tests compile themselves the sources they need. But the "units" could benefit of some decoupling so they wouldn't need pull as many sources as they do.

:warning: other problem found: `T _Z18opn2_getMusicTitleP15OPN2_MIDIPlayer`
There's this function which is maybe here for backward compability. As you can see it gets C++ mangled, and therefore useless. ADLMIDI has the same one.