### PR TITLE
fix a mistake in MAME emulator

### DIFF
--- a/src/chips/mame/mame_ym2612fm.c
+++ b/src/chips/mame/mame_ym2612fm.c
@@ -2474,7 +2474,7 @@ void ym2612_generate_one_native(void *chip, FMSAMPLE buffer[])
 	else
 	{
 		lt += dacout;
-		lt += dacout;
+		rt += dacout;
 	}
 	lt += ((out_fm[5]>>0) & OPN->pan[10]);
 	rt += ((out_fm[5]>>0) & OPN->pan[11]);


### PR DESCRIPTION
It's a probable mistake caught as I read through emulator sources.
It's not of much importance, as is related to "undocumented: DAC Test Reg" mode usage.