### PR TITLE
add safety check for emulator switching

### DIFF
--- a/src/opnmidi.cpp
+++ b/src/opnmidi.cpp
@@ -288,7 +288,7 @@ OPNMIDI_EXPORT int opn2_switchEmulator(struct OPN2_MIDIPlayer *device, int emula
         assert(play);
         if(!play)
             return -1;
-        if(play && (emulator >= 0) && (emulator < OPNMIDI_EMU_end))
+        if(opn2_isEmulatorAvailable(emulator))
         {
             play->m_setup.emulator = emulator;
             play->partialReset();

--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -90,7 +90,7 @@ OPNMIDIplay::OPNMIDIplay(unsigned long sampleRate) :
 {
     m_midiDevices.clear();
 
-    m_setup.emulator = OPNMIDI_EMU_MAME;
+    m_setup.emulator = opn2_getLowestEmulator();
     m_setup.runAtPcmRate = false;
 
     m_setup.PCM_RATE = sampleRate;

--- a/src/opnmidi_opn2.cpp
+++ b/src/opnmidi_opn2.cpp
@@ -48,6 +48,48 @@
 #include "chips/gx_opn2.h"
 #endif
 
+static const unsigned opn2_emulatorSupport = 0
+#ifndef OPNMIDI_DISABLE_NUKED_EMULATOR
+    | (1u << OPNMIDI_EMU_NUKED)
+#endif
+#ifndef OPNMIDI_DISABLE_MAME_EMULATOR
+    | (1u << OPNMIDI_EMU_MAME)
+#endif
+#ifndef OPNMIDI_DISABLE_GENS_EMULATOR
+    | (1u << OPNMIDI_EMU_GENS)
+#endif
+#ifndef OPNMIDI_DISABLE_GX_EMULATOR
+    | (1u << OPNMIDI_EMU_GX)
+#endif
+;
+
+//! Check emulator availability
+bool opn2_isEmulatorAvailable(int emulator)
+{
+    return (opn2_emulatorSupport & (1u << (unsigned)emulator)) != 0;
+}
+
+//! Find highest emulator
+int opn2_getHighestEmulator()
+{
+    int emu = -1;
+    for(unsigned m = opn2_emulatorSupport; m > 0; m >>= 1)
+        ++emu;
+    return emu;
+}
+
+//! Find lowest emulator
+int opn2_getLowestEmulator()
+{
+    int emu = -1;
+    unsigned m = opn2_emulatorSupport;
+    if(m > 0)
+    {
+        for(emu = 0; (m & 1) == 0; m >>= 1)
+            ++emu;
+    }
+    return emu;
+}
 
 static const uint32_t g_noteChannelsMap[6] = { 0, 1, 2, 4, 5, 6 };
 
@@ -283,6 +325,8 @@ void OPN2::reset(int emulator, unsigned long PCM_RATE, void *audioTickHandler)
         switch(emulator)
         {
         default:
+            assert(false);
+            abort();
 #ifndef OPNMIDI_DISABLE_MAME_EMULATOR
         case OPNMIDI_EMU_MAME:
             chip = new MameOPN2;

--- a/src/opnmidi_private.hpp
+++ b/src/opnmidi_private.hpp
@@ -1322,5 +1322,23 @@ extern void opn2_audioTickHandler(void *instance, uint32_t chipId, uint32_t rate
 #endif
 extern int opn2RefreshNumCards(OPN2_MIDIPlayer *device);
 
+/**
+ * @brief Check emulator availability
+ * @param emulator Emulator ID (Opn2_Emulator)
+ * @return true when emulator is available
+ */
+extern bool opn2_isEmulatorAvailable(int emulator);
+
+/**
+ * @brief Find highest emulator
+ * @return The Opn2_Emulator enum value which contains ID of highest emulator
+ */
+extern int opn2_getHighestEmulator();
+
+/**
+ * @brief Find lowest emulator
+ * @return The Opn2_Emulator enum value which contains ID of lowest emulator
+ */
+extern int opn2_getLowestEmulator();
 
 #endif // ADLMIDI_PRIVATE_HPP


### PR DESCRIPTION
It's the same as libADLMIDI.

One thing to take notice about: when one disables MAME, midiplay does not find its default emulator and fails (if none is given in the command).
I find desirable to have public APIs which don't need a player argument.
- get default emulator
- get name of emulator
