### PR TITLE
early koff update to prevent a bad reuse of channel

### DIFF
--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -467,6 +467,15 @@ bool OPNMIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocit
     }
 
     noteUpdate(channel, ir.first, Upd_All | Upd_Patch);
+
+    for(unsigned ccount = 0; ccount < MIDIchannel::NoteInfo::MaxNumPhysChans; ++ccount)
+    {
+        int32_t c = adlchannel[ccount];
+        if(c < 0)
+            continue;
+        m_chipChannels[c].addAge(0);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Avoidance of arpeggio problems from ADLMIDI.
Probably libOPNMIDI can have some use of this too.