### PR TITLE
implement the velocity offset

### DIFF
--- a/src/opnbank.h
+++ b/src/opnbank.h
@@ -110,6 +110,7 @@ struct opnInstMeta2
     uint16_t ms_sound_kon;  // Number of milliseconds it produces sound;
     uint16_t ms_sound_koff;
     double   fine_tune;
+    int8_t   midi_velocity_offset;
 #if 0
     opnInstMeta2() {}
     explicit opnInstMeta2(const opnInstMeta &d);
@@ -137,7 +138,7 @@ struct OpnBankSetup
 inline opnInstMeta2::opnInstMeta2(const opnInstMeta &d)
     : tone(d.tone), flags(d.flags),
       ms_sound_kon(d.ms_sound_kon), ms_sound_koff(d.ms_sound_koff),
-      fine_tune(d.fine_tune)
+      fine_tune(d.fine_tune), midi_velocity_offset(d.midi_velocity_offset)
 {
     opn[0] = ::opn[d.opnno1];
     opn[1] = ::opn[d.opnno2];

--- a/src/opnmidi_cvt.hpp
+++ b/src/opnmidi_cvt.hpp
@@ -35,7 +35,7 @@ static void cvt_generic_to_FMIns(opnInstMeta2 &ins, const WOPNI &in)
     ins.opn[0].fbalg = in.fbalg;
     ins.opn[0].lfosens = in.lfosens;
     ins.opn[0].finetune = in.note_offset;
-    /* TODO in.midi_velocity_offset */
+    ins.midi_velocity_offset = in.midi_velocity_offset;
 
     for(size_t op = 0; op < 4; op++)
     {
@@ -64,7 +64,7 @@ static void cvt_FMIns_to_generic(WOPNI &ins, const opnInstMeta2 &in)
     ins.lfosens = in.opn[0].lfosens;
     ins.note_offset = in.opn[0].finetune;
 
-    ins.midi_velocity_offset = 0; /* TODO */
+    ins.midi_velocity_offset = in.midi_velocity_offset;
 
     for(size_t op = 0; op < 4; op++)
     {

--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -222,6 +222,8 @@ bool OPNMIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocit
         MIDIchannel::activenoteiterator i = m_midiChannels[channel].activenotes_find(note);
         if(i)
         {
+            const int veloffset = i->ains->midi_velocity_offset;
+            velocity = (uint8_t)std::min(127, std::max(1, (int)velocity + veloffset));
             i->vol = velocity;
             noteUpdate(channel, i, Upd_Volume);
             return false;
@@ -310,6 +312,9 @@ bool OPNMIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocit
         if(bnk)
             ains = &bnk->ins[midiins];
     }
+
+    const int veloffset = ains->midi_velocity_offset;
+    velocity = (uint8_t)std::min(127, std::max(1, (int)velocity + veloffset));
 
     int32_t tone = note;
     if(!isPercussion && (bank > 0)) // For non-zero banks


### PR DESCRIPTION
Implement the MIDI velocity offset, which for now remains only accessible by means of `opn2_setInstrument`.
