### PR TITLE
have consistent null checks and returns

### DIFF
--- a/src/opnmidi_private.hpp
+++ b/src/opnmidi_private.hpp
@@ -66,6 +66,7 @@ typedef int32_t ssize_t;
 #include <string>
 #include <map>
 #include <set>
+#include <new> // nothrow
 #include <cstdlib>
 #include <cstring>
 #include <cmath>


### PR DESCRIPTION
Doing cleanups in the same way as on libADLMIDI side.