### PR TITLE
np2: experimental fix for SSG-EG

### DIFF
--- a/src/chips/np2/fmgen_fmgen.cpp
+++ b/src/chips/np2/fmgen_fmgen.cpp
@@ -580,7 +580,7 @@ void Operator::ShiftPhase(EGPhase nextphase)
 		break;
 
 	case release:		// Release Phase
-		if (ssg_type_)
+		if (false && ssg_type_)  // libOPNMIDI: workaround for SSG-EG
 		{
 			eg_level_ = eg_level_ * ssg_vector_ + ssg_offset_;
 			ssg_vector_ = 1;
@@ -635,7 +635,7 @@ inline FM::ISample Operator::LogToLin(uint a)
 
 inline void Operator::EGUpdate()
 {
-	if (!ssg_type_)
+	if (true || !ssg_type_)  // libOPNMIDI: workaround for SSG-EG
 	{
 		eg_out_ = Min(tl_out_ + eg_level_, 0x3ff) << (1 + 2);
 	}
@@ -679,9 +679,10 @@ void FM::Operator::EGCalc()
 		else
 		{
 			eg_level_ += 4 * decaytable1[eg_rate_][eg_curve_count_ & 7];
+			EGUpdate();  // libOPNMIDI: workaround for SSG-EG
 			if (eg_level_ >= eg_level_on_next_phase_)
 			{
-				EGUpdate();
+				// EGUpdate();  // libOPNMIDI: workaround for SSG-EG
 				switch (eg_phase_)
 				{
 				case decay:


### PR DESCRIPTION
Fully experimental attempt to fix Neko SSG-EG

- makes `EGUpdate()` happen at each step of SSG-EG case generation. observed to fix some cases of audible discontinuities in the envelope

- disables use a formula based on `ssg_vector` and `ssg_offset`. those are adjustement values of the EG output from tables, I sincerely don't know too much what they serve for.
What I know: it's broken in a way which makes EG level go very low, and makes SSG-EG operators unheard (for example, in case of "Bird Tweet" from `xg.wopn`)

Having made this edits, the EG sounds much nearer to MAME which I take as reference.
Comparison to Nuked is good in case of "Bird Tweet", however "Telephone" has a big difference from OPN2 to OPNA. Still, Neko's "Telephone" seems to lack some of timbral complexity that MAME has. (possibly, to relate with the disabled ssg stuff)