### PR TITLE
np2: experimental feature-complete SSG-EG

### DIFF
--- a/src/chips/np2/fmgen_fmgen.h
+++ b/src/chips/np2/fmgen_fmgen.h
@@ -69,9 +69,11 @@ namespace FM
 		int		tl_out_;
 		int		eg_rate_;
 		int		eg_curve_count_;
+#if 0  // libOPNMIDI: experimental SSG-EG
 		int		ssg_offset_;
 		int		ssg_vector_;
 		int		ssg_phase_;
+#endif
 		uint	key_scale_rate_;
 		EGPhase	eg_phase_;
 		uint	ms_;
@@ -90,6 +92,8 @@ namespace FM
 		bool	amon_;
 		bool	param_changed_;
 		bool	mute_;
+		bool	inverted_;
+		bool	held_;
 	};
 
 	class Operator
@@ -183,10 +187,11 @@ namespace FM
 //		int		am_depth_;		// AM depth
 		int		eg_rate_;
 		int		eg_curve_count_;
+#if 0  // libOPNMIDI: experimental SSG-EG
 		int		ssg_offset_;
 		int		ssg_vector_;
 		int		ssg_phase_;
-
+#endif
 
 		uint	key_scale_rate_;		// key scale rate
 		EGPhase	eg_phase_;
@@ -207,6 +212,8 @@ namespace FM
 		bool	amon_;		// enable Amplitude Modulation
 		bool	param_changed_;	// パラメータが更新された
 		bool	mute_;
+		bool	inverted_;
+		bool	held_;
 		
 	//	Tables ---------------------------------------------------------------
 		static Counter rate_table[16];

--- a/src/chips/np2/fmgen_fmgeninl.h
+++ b/src/chips/np2/fmgen_fmgeninl.h
@@ -53,9 +53,15 @@ inline void Operator::KeyOn()
 	if (!keyon_)
 	{
 		keyon_ = true;
+		held_ = false;
 		if (eg_phase_ == off || eg_phase_ == release)
 		{
+#if 1  // libOPNMIDI: experimental SSG-EG
+			inverted_ = ssg_type_ & 4;
+			inverted_ ^= (ssg_type_ & 2) && ar_ != 62; // try to match polarity with nuked OPN
+#else
 			ssg_phase_ = -1;
+#endif
 			ShiftPhase(attack);
 			EGUpdate();
 			in2_ = out_ = out2_ = 0;


### PR DESCRIPTION
Here is full SSG-EG including support: ALT/ATT/HOLD

I took Nuked OPN2 as basis for comparison.
I plotted the different envelopes and fixed until it matches approximately.
(16 different tests: 8 ssg modes × 2 test situations)

There was 2 cases:
- first is the ordinary case where AR=$1f. no issue
- second is the "undefined behavior" case AR≠$1f, according to documents.
In this special case, "alternate" mode toggles "inversion" bit at every cycle of attack. As such, it seems difficult to determine the final polarity with certainty, other than compute with cycle accuracy.
I made a guess matching with a test instrument, and implemented for the case AR≠$1f. It's probably wrong in cases. As a general rule, SSG-EG attack is best set to zero time.
"Alternance" flag will produce an initial glitch when there is attack time. I did not replicate this in NP2.
![capture du 2019-02-02 12-14-54](https://user-images.githubusercontent.com/17614485/52163578-2c59ea80-26e4-11e9-9794-2135d7d5393b.png)
