### PR TITLE
prevent duplicate locations in users sets

### DIFF
--- a/src/opnmidi_midiplay.cpp
+++ b/src/opnmidi_midiplay.cpp
@@ -1458,6 +1458,10 @@ void OPNMIDIplay::killOrEvacuate(size_t from_channel,
         if(adlch.users.size() == adlch.users.capacity())
             continue;  // no room for more arpeggio on channel
 
+        if(!m_chipChannels[cs].find_user(jd.loc).is_end())
+            continue;  // channel already has this note playing (sustained)
+                       // avoid introducing a duplicate location.
+
         for(OpnChannel::users_iterator m = adlch.users.begin(); !m.is_end(); ++m)
         {
             OpnChannel::LocationData &mv = m->value;


### PR DESCRIPTION
This prevents duplicates of (MidiChannel,Note) from entering users lists.
It is possible to have identical notes as distinct users, when sustain is used.
Then, `killOrEvacuate` may move the note to a chip channel where it becomes duplicate.

The code which searches users by location gets confused, because it does not expect a duplicate.
It leads to the crash in the arpeggio function.