### PR TITLE
Avoid homegrown integer types

### DIFF
--- a/src/wopn/wopn_file.h
+++ b/src/wopn/wopn_file.h
@@ -32,14 +32,6 @@
 extern "C" {
 #endif
 
-#if !defined(__STDC_VERSION__) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ < 199901L)) \
-  || defined(__STRICT_ANSI__) || !defined(__cplusplus)
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int int16_t;
-typedef unsigned short int uint16_t;
-#endif
-
 /* Type of chip for which a bank has been designed */
 typedef enum WOPN_ChipType
 {


### PR DESCRIPTION
This is intended to fix compilation errors on some operating systems.