### PR TITLE
fix variable used uninitialized and change strncpy to memcpy

### DIFF
--- a/src/midi_sequencer.hpp
+++ b/src/midi_sequencer.hpp
@@ -457,6 +457,13 @@ private:
         //! Current level on the loop stack (<0 - out of loop, 0++ - the index in the loop stack)
         int                         stackLevel;
 
+        //! Constructor to initialize member variables
+        LoopState()
+                : caughtStart(false), caughtEnd(false), caughtStackStart(false),
+                caughtStackEnd(false), caughtStackBreak(false), skipStackStart(false),
+                invalidLoop(false), temporaryBroken(false), loopsCount(-1), loopsLeft(0),
+                stackLevel(-1)
+                {}
         /**
          * @brief Reset loop state to initial
          */

--- a/src/wopn/wopn_file.c
+++ b/src/wopn/wopn_file.c
@@ -549,7 +549,7 @@ int WOPN_SaveBankToMem(WOPNFile *file, void *dest_mem, size_t length, uint16_t v
             {
                 if(length < 34)
                     return WOPN_ERR_UNEXPECTED_ENDING;
-                strncpy((char*)cursor, bankslots[i][j].bank_name, 32);
+                memcpy(cursor, bankslots[i][j].bank_name, 32);
                 cursor[32] = bankslots[i][j].bank_midi_lsb;
                 cursor[33] = bankslots[i][j].bank_midi_msb;
                 GO_FORWARD(34);


### PR DESCRIPTION
Hi, I got some warnings from gcc 14.1.0 and investigated a little in this and found 2 potential bugs.